### PR TITLE
1. Remove major-version cap from pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,26 +29,21 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-
-
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.2
-  shared_preferences: ^2.0.15
-  flutter_bloc: ^8.1.1
-  flutter_form_builder: ^7.5.0
-  form_builder_validators: ^8.3.0
-  injectable: ^2.1.0
-  get_it: ^7.2.0
-  json_annotation: ^4.6.0
-  freezed_annotation: ^2.1.0
-  retrofit: ^4.0.1
-  logger: ^1.1.0
-  go_router: ^6.2.0
-  equatable:
-  connectivity_plus:
-  firebase_remote_config:
-
+  cupertino_icons: 1.0.5
+  shared_preferences: 2.0.20
+  flutter_bloc: 8.1.2
+  flutter_form_builder: 7.8.0
+  form_builder_validators: 8.5.0
+  injectable: 2.1.1
+  get_it: 7.2.0
+  json_annotation: 4.8.0
+  freezed_annotation: 2.2.0
+  retrofit: 4.0.1
+  logger: 1.3.0
+  go_router: 6.5.0
+  equatable: 2.0.5
+  connectivity_plus: 3.0.3
+  firebase_remote_config: 3.0.15
 
 dev_dependencies:
   flutter_test:
@@ -61,14 +56,14 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^2.0.0
-  injectable_generator: ^2.1.4
-  build_runner: ^2.2.0
-  json_serializable: ^6.3.1
-  freezed: ^2.1.0+1
-  retrofit_generator: ^5.0.0
-  bloc_test:
-  mockito:
+  flutter_lints: 2.0.1
+  injectable_generator: 2.1.5
+  build_runner: 2.3.3
+  json_serializable: 6.6.1
+  freezed: 2.3.2
+  retrofit_generator: ^6.0.0+1
+  bloc_test: 9.1.1
+  mockito: 5.3.2
 
 
 # For information on the generic Dart part of this file, see the


### PR DESCRIPTION
allow dependency only with specific version